### PR TITLE
Allow for autocompletion anywhere in the arc diff message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.0.4] - 2020-01-16
+
+- [feature] Allow for autocompletion anywhere in the `arc diff` message
+
 ## [1.0.3] - 2020-01-16
 
 - [bugfix] Show correct message when there are no accepted diffs

--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -18,16 +18,25 @@ const completionProvider = ({ baseUrl }: { baseUrl: string }) =>
           return undefined;
         }
 
-        const linePrefix = document
-          .lineAt(position)
-          .text.substr(0, position.character);
-
+        // Check if one of the first 500 lines of the file start with `Reviewers:` or `Subscribers:`
+        // Only checking the first 500 lines to limit the impact on big text files
         if (
-          !linePrefix.startsWith("Reviewers:") &&
-          !linePrefix.startsWith("Subscribers:")
+          !document
+            .getText()
+            .split("\n")
+            .slice(0, 500)
+            .some(
+              value =>
+                value.startsWith("Reviewers:") ||
+                value.startsWith("Subscribers:")
+            )
         ) {
           return undefined;
         }
+
+        const linePrefix = document
+          .lineAt(position)
+          .text.substr(0, position.character);
 
         const matched = linePrefix.match(/([#@][\w-_]+)$/);
         if (!matched) {


### PR DESCRIPTION
Both @jennyscript and @janephilipps ran into the issue of autocomplete not working on the line below `Reviewers:`