### PR TITLE
Stops cache error logging from stealing focus

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -17,7 +17,6 @@ async function update() {
       label: errorMessage
     });
     log.append(errorMessage);
-    log.show();
   }
 }
 


### PR DESCRIPTION
When something goes wrong and the extension can't contact phabricator (I suspect because of ratelimiting) the error message steals focus from the current editor window. This message is useful, but not critical to operation. Stopping it stealing focus helps developers maintain their focus.

Fixes #8