### PR TITLE
[bugfix] Avoid constant language switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "configurationDefaults": {
+      "[plaintext]": {
+        "workbench.editor.languageDetection": false
+      }
+    },
     "configuration": [
       {
         "title": "Phabricator",


### PR DESCRIPTION
Every typed character resulted in VSCode changing the language back to Markdown.

Uses https://code.visualstudio.com/api/references/contribution-points#contributes.configurationDefaults

![vscode-phabricator-avoid-constant-switching-language](https://user-images.githubusercontent.com/127199/140328658-8dee14cd-831d-40dd-92fb-7fe0bcbaa6e8.gif)
